### PR TITLE
fix: Permit a package to not be in proposed or staging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -211,7 +211,6 @@ function repo_build {
                 cp -a "${staging_pool}" "${partial_pool}"
             else
                 echo "    Failed to find '${version}' in staging or release" >&2
-                exit 1
             fi
         fi
     done


### PR DESCRIPTION
Fixes the following

```
20:29:55 installer bionic
20:29:55   - sync: 0.0.1~1640109341~18.04~ef6f2f1
20:29:55   - staging: None
20:29:55   - release: None
20:29:55     Failed to find '0.0.1~1640109341~18.04~ef6f2f1' in staging or release
20:29:55 Build step 'Execute shell' marked build as failure
```