### PR TITLE
Add ticks around removed versions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -187,7 +187,7 @@ function repo_sync {
 
             dist_summary+=(
                 "  - ${repo}"
-                "    - Removed ${version}"
+                "    - Removed \`${version}\`"
             )
             total="$(expr "${total}" + 1)"
         done


### PR DESCRIPTION
This fixes the formatting of the automatically generated commit message