### PR TITLE
Include appstream data in repository

### DIFF
--- a/asgen-config.json
+++ b/asgen-config.json
@@ -1,0 +1,24 @@
+{
+    "ProjectName": "Pop!_OS",
+    "ArchiveRoot": "./build/release.partial",
+    "Backend": "debian",
+    "Features": {
+        "processDesktop": true
+    },
+    "Suites": {
+        "impish": {
+            "sections": ["main"],
+            "architectures": ["amd64", "arm64", "i386"]
+        },
+        "jammy": {
+            "sections": ["main"],
+            "architectures": ["amd64", "arm64", "i386"]
+	}
+    }
+  },
+ "Icons":
+  {
+    "64x64":   {"cached": true, "remote": false},
+    "128x128": {"cached": true, "remote": false}
+  }
+}

--- a/build.sh
+++ b/build.sh
@@ -367,6 +367,15 @@ function repo_build {
             fi
         done
 
+        pushd ../..
+        appstream-generator run ${dist}
+        popd
+        for comp in "${COMPONENTS[@]}"
+        do
+            cp -r "../../export/data/${dist}/${comp}" "${dists_dir}/${comp}/dep11"
+            gzip -dk "${dists_dir}/${comp}/dep11/"*.gz
+        done
+
         pushd "${dists_dir}"
         set -x
         apt-ftparchive \


### PR DESCRIPTION
Eliminates the need for https://github.com/pop-os/appstream-data which was a workaround for appstream data on a PPA.

To test, remove `appstream-data` package. System76 Keyboard Configurator and Mouse Configurator will no longer show up in Pop!_Shop. Popsicle will only show Flatpak version.

A version of `repo-release` can be build and used locally with:

```
sudo apt install appstream-generator
gpg --full-gen-key
./build.sh --yes
./build.sh --build
gpg --armor --export | sudo tee /etc/apt/trusted.gpg.d/repo-release-test.asc
python3 -m http.server -d build/release
```

Changing `/etc/apt/sources.list.d/pop-os-release.sources` to have `URIs: http://localhost:8000`, and running `sudo apt update` will then fetch the appstream data. The apps should then show in Pop!_Shop again.