### PR TITLE
Revert "Disable Impish (#151)"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ ARCHIVE=apt.pop-os.org/staging/master
 COMPONENTS=(main)
 # Distributions to mirror
 DISTS=(
+    impish
     jammy
 )
 # Architectures to mirror


### PR DESCRIPTION
This reverts commit 16ddc69f0954dced0456d38988fd225808f52375 to re-enable the Impish release repo.

The rationale for this is that pop-upgrade is now failing on customers' systems who are still running the end-of-life 21.10 release (due to 404 errors in `sudo apt update` output since the release repo is gone.) The support team would like pop-upgrade to continue working instead of having to walk customers through manual upgrades or refresh installs.

repo-release mirrors master staging, and master staging [still includes Impish](http://apt-origin.pop-os.org/staging/master/dists/impish/) (and [Impish builds weren't disabled yet](https://github.com/pop-os/pop/blob/8aea51a54f0b06a19fb97ff71fc0816a431a1c43/scripts/pop-ci/src/repo.rs#L112)), so I _think_ this may be okay to do. However, for the engineering review, please say something if this is a bad idea.