### PR TITLE
Require correct binary builds to release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ declare -A ARCHS_MAP=(
 )
 
 GPG_FLAGS=(
-    --batch --yes \
+    --batch --yes --ignore-binary \
     --digest-algo sha512 \
 )
 if [ -n "${DEBEMAIL}" ]
@@ -45,6 +45,7 @@ then
 fi
 
 build="0"
+ignore_binary="0"
 pull="1"
 sync="1"
 yes="0"
@@ -54,6 +55,9 @@ do
         "--build")
             build="1"
             sync="0"
+            ;;
+        "--ignore-binary") # Allow package release even if binary failed to build
+            ignore_binary="1"
             ;;
         "--yes")
             yes="1"
@@ -143,11 +147,11 @@ function repo_sync {
             fi
 
 	    # Test if all architechtures in the debian/control file actually built. Set all_built to false if they havent all built.
-	    all_built=true
+	    all_built=1
 	    declare -a test_archs
 	    builds_for=$(cat build/mirror/${ARCHIVE}/pool/${dist}/${repo}/*/*.dsc | grep "^Arch") 
 	    for arch in $builds_for; do
-		if ! $all_built; then
+		if ! [ $all_built == 1 ]; then
 			break
 		fi
 
@@ -160,15 +164,15 @@ function repo_sync {
                 for a in "${test_archs[@]}"; do
 
 		    if ! grep -qP "Filename: pool/${dist}/${repo}/" build/mirror/${ARCHIVE}/dists/${dist}/main/binary-${a}/Packages; then
-			all_built=false
+			all_built=0
 	                echo -e "\e[1;33m  * ${repo} cannot be released because not all architechtures in 'debian/control' built.\e[0m"
 			break
                     fi
                 done
 	    done
 
-	    # Now ask if we should sync if staging has a newer version and all architechtures have built
-            if $all_built && dpkg --compare-versions "${staging_version}" gt "${version}"
+	    # Now ask if we should sync if ( all architechtures built or --ignore-binary flag passed ) and a newer version is available
+	    if [ $((`expr $all_built + $ignore_binary`)) -ge 1 ] && dpkg --compare-versions "${staging_version}" gt "${version}"
             then
                 if [ "$yes" == "1" ]
                 then

--- a/build.sh
+++ b/build.sh
@@ -23,10 +23,16 @@ ARCHS=(
     arm64
     src
 )
-# Architectures we want to guarentee built (currently our build server doesn't build i386)
-GUARANTEED_ARCHS=(
-    amd64
-    arm64
+# A mapping of debian architechtures to output folder names
+# Any architechtures listed here are required to build before a
+# package can be released.
+declare -A ARCHS_MAP=(
+    [amd64]="amd64"
+    [arm64]="arm64"
+    [i386]="i386"
+    [linux-any]="amd64 arm64"
+    [any]="amd64 arm64 i386"
+    [all]="amd64 arm64 i386"
 )
 
 GPG_FLAGS=(
@@ -146,16 +152,10 @@ function repo_sync {
 		fi
 
 		unset test_archs
-                for a in "${GUARANTEED_ARCHS[@]}"; do
-                    if [[ "$arch" == "$a" ]]; then
-		        test_archs+=("$a")
-                    elif [[ "$arch" == "linux-any" || "$arch" == "all" || "$arch" == "any" ]]; then
-			for b in "${GUARANTEED_ARCHS[@]}"; do
-				test_archs+=($b)
-			done
-			break
-                    fi
-                done
+		archs=( "${ARCHS_MAP[$arch]}" )
+		for a in "${archs[@]}"; do
+                    test_archs+=($a)
+		done
 
                 for a in "${test_archs[@]}"; do
 

--- a/build.sh
+++ b/build.sh
@@ -118,6 +118,10 @@ function repo_sync {
 
             #TODO: make sure only one dsc exists
             staging_dsc="$(echo "${staging_pool}/"*".dsc")"
+	    if [[ -z $staging_dsc ]]; then
+                echo -e "\e[1;33m  * ${repo} is missing a .dsc file. Packaging is incorrect. ${repo} cannot be released.\e[0m"
+		continue
+            fi
             #TODO: make sure only one version exists
             staging_version="$(grep "^Version: " "${staging_dsc}" | cut -d " " -f 2-)"
             staging_commit="$(basename "${staging_pool}")"


### PR DESCRIPTION
A package must now build for all architectures in its `debian/control` file to be released. If not, a yellow warning is printed in the console, and the sync is skipped.

This is done by checking the architectures that that the package builds for, then checking if that package shows up in each binary `Packages` file. A small quirk is the filename is checked for, because the build script only gives us access to the git reponame, not the build package name. But there should never be a conflict there anyway.

Out build server only properly builds on amd64 and arm64, so we filter to only test those architectures at most.

Closes #155 