### PR TITLE
Add create-release github action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,16 @@
+name: create release
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "v${{ github.run_number }}" --notes "$(git log -1 --pretty=%B)"


### PR DESCRIPTION
The PR adds `create release` GitHub action.
The action creates a GitHub release on each commit to the `main` branch.
The release tag is `v${{ github.run_number }}`. Where `github.run_number` is a unique number for each run of a particular workflow in a repository. This number begins at 1 for the workflow's first run, and increments with each new run. This number does not change if you re-run the workflow run. So the tag will be `v1` `v2` etc.
The release notes are the last commit message. The release's title will be the tag + the first line of the notes. E.g. `v1: Updated 2 packages`

GitHub releases are published as RSS feed.  The feed is available at `https://github.com/:owner/:repo/releases.atom `
 I'm adding this feature to get notified when the new version of packages is released. So I can check the diffs and test the latest changes.