### PR TITLE
Copy from staging if possible, fixes release repo missing newly built arches

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -344,15 +344,15 @@ function repo_build {
 
         partial_pool="build/release.partial/pool/${dist}/${repo}/${commit}"
         mkdir -p "$(dirname "${partial_pool}")"
-        if [ "${release}" == "${version}" ]
+        if [ "${staging}" == "${version}" ]
         then
-            echo "    Version '${version}' already in release"
-            cp -a "${release_pool}" "${partial_pool}"
+            echo "    Copying '${version}' from staging to release"
+            cp -a "${staging_pool}" "${partial_pool}"
         else
-            if [ "${staging}" == "${version}" ]
+            if [ "${release}" == "${version}" ]
             then
-                echo "    Copying '${version}' from staging to release"
-                cp -a "${staging_pool}" "${partial_pool}"
+                echo "    Keeping '${version}' already in release"
+                cp -a "${release_pool}" "${partial_pool}"
             else
                 echo "    Failed to find '${version}' in staging or release" >&2
                 exit 1


### PR DESCRIPTION
I noticed the release repo was missing some arm64 packages that were in master staging. This change should ensure the release repo always matches the staging repo.